### PR TITLE
add feature to expose anyhow errors

### DIFF
--- a/yerpc/Cargo.toml
+++ b/yerpc/Cargo.toml
@@ -16,3 +16,7 @@ anyhow = { version = "1.0.52", optional = true }
 futures = "0.3.19"
 async-channel = "1.6.1"
 async-mutex = "1.4.0"
+
+
+[features]
+anyhow_expose = []

--- a/yerpc/src/lib.rs
+++ b/yerpc/src/lib.rs
@@ -1,6 +1,7 @@
 pub use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use serde_json::Value;
 pub use yerpc_derive::rpc;
 
 mod requests;
@@ -195,6 +196,19 @@ impl From<serde_json::Error> for Error {
 }
 
 #[cfg(feature = "anyhow")]
+#[cfg(feature = "anyhow_expose")]
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        Self {
+            code: -1,
+            message: format!("{:?}", error),
+            data: None,
+        }
+    }
+}
+
+#[cfg(feature = "anyhow")]
+#[cfg(not(feature = "anyhow_expose"))]
 impl From<anyhow::Error> for Error {
     fn from(_error: anyhow::Error) -> Self {
         Self {

--- a/yerpc/src/lib.rs
+++ b/yerpc/src/lib.rs
@@ -1,7 +1,6 @@
 pub use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use serde_json::Value;
 pub use yerpc_derive::rpc;
 
 mod requests;


### PR DESCRIPTION
deltachat needs that, because it does behave more like an application than a library (no good errors with distict codes).
also deltachat is local only so hiding errors makes not much sense.

side note: when hiding the error it should be logged somewhere, otherwise admins can not help if the error is discarded.
