### PR TITLE
improve client code

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "dependencies": {
     "@types/ws": "^8.2.2",
     "isomorphic-ws": "^4.0.1",
+    "tiny-emitter": "git+https://github.com/Simon-Laux/tiny-emitter.git",
     "typescript": "^4.5.5"
+  },
+  "optionalDependencies": {
+    "ws": "^8.5.0"
   }
 }

--- a/typescript/client.ts
+++ b/typescript/client.ts
@@ -2,7 +2,7 @@ import WebSocket from 'isomorphic-ws'
 import { TinyEmitter } from 'tiny-emitter';
 import { Request, Response, Message, Error, Params } from './jsonrpc'
 
-interface Transport {
+export interface Transport {
   request: (method: string, params?: Params) => Promise<unknown>,
   notification: (method: string, params?: Params) => void
 }

--- a/typescript/client.ts
+++ b/typescript/client.ts
@@ -20,9 +20,9 @@ type Options = {
 
 // type RequestEvent = WebSocket.MessageEvent<Request>;
 
-
-type ClientHandlerEvents = {
+export type ClientHandlerEvents = {
   "request": (request: Request) => void,
+  [key:string]: (...ev:any) =>void
 }
 export abstract class ClientHandler extends TinyEmitter<ClientHandlerEvents> implements Transport {
   private _requests: RequestMap = new Map();

--- a/yerpc/Cargo.toml
+++ b/yerpc/Cargo.toml
@@ -16,3 +16,7 @@ anyhow = { version = "1.0.52", optional = true }
 futures = "0.3.19"
 async-channel = "1.6.1"
 async-mutex = "1.4.0"
+
+
+[features]
+anyhow_expose = []

--- a/yerpc/src/lib.rs
+++ b/yerpc/src/lib.rs
@@ -1,6 +1,7 @@
 pub use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use serde_json::Value;
 pub use yerpc_derive::rpc;
 
 mod requests;
@@ -195,6 +196,19 @@ impl From<serde_json::Error> for Error {
 }
 
 #[cfg(feature = "anyhow")]
+#[cfg(feature = "anyhow_expose")]
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        Self {
+            code: -1,
+            message: format!("{:?}", error),
+            data: None,
+        }
+    }
+}
+
+#[cfg(feature = "anyhow")]
+#[cfg(not(feature = "anyhow_expose"))]
 impl From<anyhow::Error> for Error {
     fn from(_error: anyhow::Error) -> Self {
         Self {

--- a/yerpc/src/lib.rs
+++ b/yerpc/src/lib.rs
@@ -1,7 +1,6 @@
 pub use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use serde_json::Value;
 pub use yerpc_derive::rpc;
 
 mod requests;


### PR DESCRIPTION
- add feature to expose anyhow errors
- remove unused import
- use `tiny-emitter` for event emitting (previous thing was not working in my nodejs and not properly typed)
- export transport interface
- export ClientHandlerEvents and allow any events there
