### PR TITLE
feat: add `RpcSession::server()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- add `RpcSession::server()` method
+
 ## 0.4.2
 
 - rust packages are unchanged from 0.4.1

--- a/yerpc/src/requests.rs
+++ b/yerpc/src/requests.rs
@@ -38,8 +38,14 @@ impl<T: RpcServer> RpcSession<T> {
         Self { client, server }
     }
 
+    /// Returns a reference to the JSON-RPC client.
     pub fn client(&self) -> &RpcClient {
         &self.client
+    }
+
+    /// Returns a reference to the JSON-RPC server.
+    pub fn server(&self) -> &T {
+        &self.server
     }
 
     pub fn into_sink(self) -> RpcSessionSink<T> {


### PR DESCRIPTION
Closes #48.

This way it is possible to get the server and call any method directly.