### PR TITLE
feat: add `RpcSession::handle_incoming_parsed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Add `RpcSession::handle_incoming_parsed`
+  and `RpcSession::process_incoming_parsed`
+
 ## 0.6.0 - 2024-07-06
 
 - ts client: fix memory leak


### PR DESCRIPTION
...and `RpcSession::process_incoming_parsed`.

Use case: in the Tauri version of Delta Chat,
messages are already serialized by Tauri, so we don't need
to re-serialize them.
For reference, see
https://github.com/deltachat/deltachat-desktop/pull/4810.
