### PR TITLE
fix: Remove anyhow: prefix that was added to all messages

### DIFF
--- a/yerpc/src/lib.rs
+++ b/yerpc/src/lib.rs
@@ -269,7 +269,7 @@ impl From<anyhow::Error> for Error {
     fn from(error: anyhow::Error) -> Self {
         Self {
             code: -1,
-            message: format!("anyhow: {:#}", error),
+            message: format!("{:#}", error),
             data: None,
         }
     }


### PR DESCRIPTION
Since https://github.com/chatmail/yerpc/pull/64, an "anyhow: " prefix is added to all anyhow errors. This leads to weird-looking error messages being presented to the end user:

![image](https://github.com/user-attachments/assets/2419b658-0a7d-4bcf-b8ff-ddbd044d9d40)

Since most people don't know what "anyhow" is, this PR removes it again.