### PR TITLE
Update schemars from 0.8 to 1.0

### DIFF
--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -24,5 +24,5 @@ tokio = { version = "1.43.0", features = ["full"] }
 tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-schemars = "0.9.0"
+schemars = "1"
 yerpc = { path  = "../../yerpc", features = ["anyhow", "support-axum"]}

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -24,5 +24,5 @@ tokio = { version = "1.43.0", features = ["full"] }
 tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-schemars = "0.8.21"
+schemars = "0.9.0"
 yerpc = { path  = "../../yerpc", features = ["anyhow", "support-axum"]}

--- a/examples/tide/Cargo.toml
+++ b/examples/tide/Cargo.toml
@@ -20,7 +20,7 @@ async-std = { version = "1.11.0", features = ["attributes"] }
 futures = "0.3.31"
 env_logger = "0.9.0"
 log = "0.4.25"
-schemars = "0.8.22"
+schemars = "0.9.0"
 async-trait = "0.1.53"
 typescript-type-def = { version = "0.5.13", features = ["json_value"] }
 async-broadcast = "0.4.0"

--- a/examples/tide/Cargo.toml
+++ b/examples/tide/Cargo.toml
@@ -20,7 +20,7 @@ async-std = { version = "1.11.0", features = ["attributes"] }
 futures = "0.3.31"
 env_logger = "0.9.0"
 log = "0.4.25"
-schemars = "0.9.0"
+schemars = "1"
 async-trait = "0.1.53"
 typescript-type-def = { version = "0.5.13", features = ["json_value"] }
 async-broadcast = "0.4.0"

--- a/yerpc/Cargo.toml
+++ b/yerpc/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 
 # type generating dependencies
 typescript-type-def = { version = "0.5.13", features = ["json_value"] }
-schemars = { version = "0.8.21", optional = true }
+schemars = { version = "0.9.0", optional = true }
 
 # optional dependencies
 anyhow = { version = "1.0.95", optional = true }

--- a/yerpc/Cargo.toml
+++ b/yerpc/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 
 # type generating dependencies
 typescript-type-def = { version = "0.5.13", features = ["json_value"] }
-schemars = { version = "0.9.0", optional = true }
+schemars = { version = "1", optional = true }
 
 # optional dependencies
 anyhow = { version = "1.0.95", optional = true }


### PR DESCRIPTION
This requires some migration:
https://graham.cool/schemars/migrating/

Turns out we did not test schemars in CI, so I pushed change enabling "openrpc" feature in CI: https://github.com/chatmail/yerpc/commit/8f85557b9a9a0ba4dc873aac81132cc5e2011e70

Now this PR fails CI because API usage was not migrated.