### PR TITLE
improvement: mark `_send` as `abstract`, add docs

### DIFF
--- a/typescript/client.ts
+++ b/typescript/client.ts
@@ -21,12 +21,14 @@ export abstract class BaseTransport<T = {}>
 {
   private _requests: RequestMap = new Map();
   private _requestId = 0;
-  _send(_message: Message): void {
-    throw new Error("_send method not implemented");
-  }
+  abstract _send(_message: Message): void
 
   close() {}
 
+  /**
+   * This must be invoked by the implementor of {@link BaseTransport},
+   * on incoming messages.
+   */
   protected _onmessage(message: Message): void {
     if ((message as Request).method) {
       const request = message as Request;


### PR DESCRIPTION
This should make it easier to understand the purpose of the class
and how to work with it.

TODO:
- [ ] This might be considered breaking? Because this requires that `_send` to be implemented at TypeScript compile time.
  But it wouldn't make sense not to implement it because otherwise it throws.
