### PR TITLE
typescript-client: Remove dependencies on WebSockets npm packages (`@types/ws`, `ws` and `isomorphic-ws`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# Unreleased
+- typescript-client: Remove dependencies on WebSockets npm packages (`@types/ws`, `ws` and `isomorphic-ws`).
+- typescript-client: Set the minimum Node.js version to `22`, because that's the version where support for the standard WebSockets was stabilized.
+
 ## 0.6.4 - 2025-04-17
 
 - Remove 'anyhow:' prefix from errors.
@@ -69,4 +73,4 @@ This release adds [OpenRPC](https://open-rpc.org/) generation support.
 
 ## Older
 
-see git commit history for older releases 
+see git commit history for older releases

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -5,3 +5,5 @@ A TypeScript integration for the [yerpc](https://github.com/deltachat/yerpc) JSO
 See the [main README](https://github.com/deltachat/yerpc/blob/main/README.md) for details.
 
 *TODO: Add more docs*
+
+The minimum nodejs version for this package is `22` if you want to use the `WebsocketTransport`.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -28,16 +28,14 @@
     "prepublishOnly": "run-s lint clean build"
   },
   "dependencies": {
-    "@types/ws": "^8.2.2",
-    "isomorphic-ws": "^4.0.1",
     "typescript": "^4.6.3"
-  },
-  "optionalDependencies": {
-    "ws": "^8.5.0"
   },
   "devDependencies": {
     "esbuild": "^0.17.9",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/typescript/websocket.ts
+++ b/typescript/websocket.ts
@@ -1,4 +1,3 @@
-import WebSocket from "isomorphic-ws";
 import { Message } from "./jsonrpc.js";
 import { BaseTransport } from "./client.js";
 import { Emitter, EventsT } from "./util/emitter.js";
@@ -9,12 +8,19 @@ type WebsocketOptions = {
   maxReconnectInterval: number;
 };
 
-export type WebSocketErrorEvent = WebSocket.ErrorEvent;
+type WSMessageEvent = Parameters<
+  Exclude<typeof WebSocket.prototype.onmessage, null>
+>[0];
+type WSErrorEvent = Parameters<
+  Exclude<typeof WebSocket.prototype.onerror, null>
+>[0];
+
+export type WebSocketErrorEvent = WSErrorEvent;
 
 export interface WebsocketEvents extends EventsT {
   connect: () => void;
   disconnect: () => void;
-  error: (error: WebSocket.ErrorEvent) => void;
+  error: (error: WSErrorEvent) => void;
 }
 
 export class WebsocketTransport extends BaseTransport<WebsocketEvents> {
@@ -27,7 +33,7 @@ export class WebsocketTransport extends BaseTransport<WebsocketEvents> {
   }
   constructor(public url: string, options?: WebsocketOptions) {
     super();
-    const onmessage = (event: WebSocket.MessageEvent) => {
+    const onmessage = (event: WSMessageEvent) => {
       const message: Message = JSON.parse(event.data as string);
       this._onmessage(message);
     };
@@ -35,7 +41,7 @@ export class WebsocketTransport extends BaseTransport<WebsocketEvents> {
 
     this._socket.on("connect", () => this.emit("connect"));
     this._socket.on("disconnect", () => this.emit("disconnect"));
-    this._socket.on("error", (error: WebSocket.ErrorEvent) =>
+    this._socket.on("error", (error: WSErrorEvent) =>
       this.emit("error", error)
     );
   }
@@ -59,12 +65,12 @@ class ReconnectingWebsocket extends Emitter<WebsocketEvents> {
   private _connected = false;
   private _reconnectAttempts = 0;
 
-  onmessage: (event: WebSocket.MessageEvent) => void;
+  onmessage: (event: WSMessageEvent) => void;
   closed = false;
 
   constructor(
     public url: string,
-    onmessage: (event: WebSocket.MessageEvent) => void,
+    onmessage: (event: WSMessageEvent) => void,
     options?: WebsocketOptions
   ) {
     super();


### PR DESCRIPTION
Also set the minimum Node.js version to `22`, because that's the version
where support for the standard WebSockets was stabilized.

Closes #46 
